### PR TITLE
Dialer: Whitelist few EU countries for call recording

### DIFF
--- a/res/values-mcc204/config.xml
+++ b/res/values-mcc204/config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-     Copyright (C) 2014 The CyanogenMod Project
+     Copyright (C) 2015 The CyanogenMod Project
 
      Licensed under the Apache License, Version 2.0 (the "License");
      you may not use this file except in compliance with the License.
@@ -14,6 +14,9 @@
      See the License for the specific language governing permissions and
      limitations under the License.
 -->
+
+<!--Allow recording for country: Netherlands-->
+<!--Legal precedent source: http://blog.wetrecht.nl/telefoongesprekken-opnemen-als-bewijs-kan-dat/ -->
 <resources>
-    <bool name="call_recording_enabled">false</bool>
+
 </resources>

--- a/res/values-mcc214/config.xml
+++ b/res/values-mcc214/config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-     Copyright (C) 2014 The CyanogenMod Project
+     Copyright (C) 2015 The CyanogenMod Project
 
      Licensed under the Apache License, Version 2.0 (the "License");
      you may not use this file except in compliance with the License.
@@ -14,6 +14,9 @@
      See the License for the specific language governing permissions and
      limitations under the License.
 -->
+
+<!--Allow recording for country: Spain-->
+<!--Legal precedent source: http://www.legalisconsultores.es/2014/04/es-legal-realizar-grabacionesse-pueden-aportar-como-prueba-en-juicios/ -->
 <resources>
-    <bool name="call_recording_enabled">false</bool>
+
 </resources>

--- a/res/values-mcc222/config.xml
+++ b/res/values-mcc222/config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-     Copyright (C) 2014 The CyanogenMod Project
+     Copyright (C) 2015 The CyanogenMod Project
 
      Licensed under the Apache License, Version 2.0 (the "License");
      you may not use this file except in compliance with the License.
@@ -14,6 +14,9 @@
      See the License for the specific language governing permissions and
      limitations under the License.
 -->
+
+<!--Allow recording for country: Italy-->
+<!--Legal precedent source: http://www.altalex.com/index.php?idnot=53369 -->
 <resources>
-    <bool name="call_recording_enabled">false</bool>
+
 </resources>

--- a/res/values-mcc230/config.xml
+++ b/res/values-mcc230/config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-     Copyright (C) 2014 The CyanogenMod Project
+     Copyright (C) 2015 The CyanogenMod Project
 
      Licensed under the Apache License, Version 2.0 (the "License");
      you may not use this file except in compliance with the License.
@@ -14,6 +14,9 @@
      See the License for the specific language governing permissions and
      limitations under the License.
 -->
+
+<!--Allow recording for country: Czech Republic-->
+<!--Legal precedent source: http://nalus.usoud.cz/Search/GetText.aspx?sz=1-191-05_2 -->
 <resources>
-    <bool name="call_recording_enabled">false</bool>
+
 </resources>

--- a/res/values-mcc238/config.xml
+++ b/res/values-mcc238/config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-     Copyright (C) 2014 The CyanogenMod Project
+     Copyright (C) 2015 The CyanogenMod Project
 
      Licensed under the Apache License, Version 2.0 (the "License");
      you may not use this file except in compliance with the License.
@@ -14,6 +14,9 @@
      See the License for the specific language governing permissions and
      limitations under the License.
 -->
+
+<!--Allow recording for country: Denmark-->
+<!--Legal precedent source: https://www.retsinformation.dk/Forms/r0710.aspx?id=164192#Kap27 -->
 <resources>
-    <bool name="call_recording_enabled">false</bool>
+
 </resources>

--- a/res/values-mcc240/config.xml
+++ b/res/values-mcc240/config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-     Copyright (C) 2014 The CyanogenMod Project
+     Copyright (C) 2015 The CyanogenMod Project
 
      Licensed under the Apache License, Version 2.0 (the "License");
      you may not use this file except in compliance with the License.
@@ -14,6 +14,9 @@
      See the License for the specific language governing permissions and
      limitations under the License.
 -->
+
+<!--Allow recording for country: Sweden-->
+<!--Legal precedent source: https://lagen.nu/begrepp/Olovlig_avlyssning -->
 <resources>
-    <bool name="call_recording_enabled">false</bool>
+
 </resources>

--- a/res/values-mcc242/config.xml
+++ b/res/values-mcc242/config.xml
@@ -15,8 +15,8 @@
      limitations under the License.
 -->
 
-<!--Allow recording for country: Finland-->
-<!--Legal precedent source: http://www.tietosuoja.fi/fi/index/ratkaisut/puheluidennauhoittaminen.html -->
+<!--Allow recording for country: Norway-->
+<!--Legal precedent source: https://www.datatilsynet.no/verktoy-skjema/Veiledere/Lydopptak-/ -->
 <resources>
 
 </resources>

--- a/res/values-mcc260/config.xml
+++ b/res/values-mcc260/config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-     Copyright (C) 2014 The CyanogenMod Project
+     Copyright (C) 2015 The CyanogenMod Project
 
      Licensed under the Apache License, Version 2.0 (the "License");
      you may not use this file except in compliance with the License.
@@ -14,6 +14,9 @@
      See the License for the specific language governing permissions and
      limitations under the License.
 -->
+
+<!--Allow recording for country: Poland-->
+<!--Legal precedent source: http://www.giodo.gov.pl/data/filemanager_pl/467.doc -->
 <resources>
-    <bool name="call_recording_enabled">false</bool>
+
 </resources>


### PR DESCRIPTION
All entries to this list patch should state the country being modified
and
provide a URL reference (either government law, precedent or similar).

A disclaimer item will also be added to the InCallUI view for the user
to
acknowledge that it is their responsibility to conduct/maintain and use
recordings in conjunction with their respective country/region's laws.

Change-Id: Id6aa02447e9e8b6520cbe7c6eada7df333ee42a0