### PR TITLE
Dialer: remove contact importing from Dialer

### DIFF
--- a/res/menu/dialtacts_options.xml
+++ b/res/menu/dialtacts_options.xml
@@ -20,9 +20,6 @@
         android:icon="@drawable/ic_menu_history_lt"
         android:title="@string/action_menu_call_history_description" />
     <item
-        android:id="@+id/menu_import_export"
-        android:title="@string/menu_import_export" />
-    <item
         android:id="@+id/menu_clear_frequents"
         android:title="@string/menu_clear_frequents" />
     <item

--- a/src/com/android/dialer/DialtactsActivity.java
+++ b/src/com/android/dialer/DialtactsActivity.java
@@ -646,14 +646,6 @@ public class DialtactsActivity extends TransactionSafeActivity implements View.O
                     toast.show();
                 }
                 break;
-            case R.id.menu_import_export:
-                // We hard-code the "contactsAreAvailable" argument because doing it properly would
-                // involve querying a {@link ProviderStatusLoader}, which we don't want to do right
-                // now in Dialtacts for (potential) performance reasons. Compare with how it is
-                // done in {@link PeopleActivity}.
-                ImportExportDialogFragment.show(getFragmentManager(), true,
-                        DialtactsActivity.class);
-                return true;
             case R.id.menu_clear_frequents:
                 ClearFrequentsDialog.show(getFragmentManager());
                 return true;


### PR DESCRIPTION
Dialer uses a different code path for importing contacts than the contacts app
which is broken.  Since you can already import via contacts, this is redundant.

Change-Id: I1172bf0a16bfbdcaa8835842edc1b1635cc8d62d